### PR TITLE
exit code fixed and -I option added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: bash
+
+script:
+    - make install
+    - make uninstall

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: bash
 
 script:
-    - make install
-    - make uninstall
+    - make test

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,14 @@
 PREFIX=/bin
 
 install:
-	@if [ ! -e $(PREFIX)/rm.bak ]; then \
-		echo "... backup $(PREFIX)/rm to $(PREFIX)/rm.bak"; \
-		cp $(PREFIX)/rm $(PREFIX)/rm.bak; \
-	fi
-
-	@cp bin/rm.sh $(PREFIX)/rm
-	@chmod 755 $(PREFIX)/rm
-	@echo "Installation Succeeded! Enjoy!"
+	@cp bin/rm.sh $(PREFIX)/safe-rm
+	@chmod 755 $(PREFIX)/safe-rm
+	@echo "Installation Succeeded!"
+	@echo "Please add \"alias rm='$(PREFIX)/safe-rm'\" to your ~/.bashrc script"
+	@echo "Enjoy!"
 
 uninstall:
-	@cp $(PREFIX)/rm.bak $(PREFIX)/rm
-	@chmod 755 $(PREFIX)/rm
-	@echo "Successfully recovered to the original rm"
+	@rm $(PREFIX)/safe-rm
+	@echo "Please remove \"alias rm='$(PREFIX)/safe-rm'\" from your ~/.bashrc script"
+	@echo "and do 'unalias rm' from all your terminal sessions"
+	@echo "Successfully removed $(PREFIX)/safe-rm"

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ uninstall:
 	@echo "Please remove \"alias rm='$(PREFIX)/safe-rm'\" from your ~/.bashrc script"
 	@echo "and do 'unalias rm' from all your terminal sessions"
 	@echo "Successfully removed $(PREFIX)/safe-rm"
+
+test:
+	@echo "Testing safe-rm"

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-     _______  _______  _______  _______         ______    __   __ 
-    |       ||   _   ||       ||       |       |    _ |  |  |_|  |
-    |  _____||  |_|  ||    ___||    ___| ____  |   | ||  |       |
-    | |_____ |       ||   |___ |   |___ |____| |   |_||_ |       |
-    |_____  ||       ||    ___||    ___|       |    __  ||       |
-     _____| ||   _   ||   |    |   |___        |   |  | || ||_|| |
-    |_______||__| |__||___|    |_______|       |___|  |_||_|   |_|
 
-A much safer replacement of bash rm with **ALMOST FULL** features of the origin rm command.
+     _______  _______  _______  _______         ______    __   __  
+    |       ||   _   ||       ||       |       |    _ |  |  |_|  |  
+    |  _____||  |_|  ||    ___||    ___| ____  |   | ||  |       |  
+    | |_____ |       ||   |___ |   |___ |____| |   |_||_ |       |  
+    |_____  ||       ||    ___||    ___|       |    __  ||       |  
+     _____| ||   _   ||   |    |   |___        |   |  | || ||_|| |  
+    |_______||__| |__||___|    |_______|       |___|  |_||_|   |_|  
 
-Mac OS X **ONLY** so far. (Maybe safe-rm could also work on other operating system, untested though :p )
+A much safer replacement of bash `rm` with **ALMOST FULL** features of the origin `rm` command.
 
-Using safe-rm, the files or directories you choose to remove will move to Trash(OS X) instead of simply deleting them. You could put them back whenever you want manually.
+Initially developed on Mac OS X, then tested on Linux.
+
+Using `safe-rm`, the files or directories you choose to remove will move to `$HOME/.Trash` instead of simply deleting them. You could put them back whenever you want manually.
 
 If a file or directory with the same name already exists in the Trash, the name of newly-deleted items will be ended with the current date and time.
 
@@ -38,14 +39,18 @@ Normally:
 
 	make && sudo make install
 	# and enjoy
-	
+
 For those who have no `make` command:
 
 	sudo sh install.sh
-	
-Installing safe-rm will replace the original `/bin/rm` of Mac OS X which will be backed up before replacing.
-	
-After installation, when you execute `rm` command in the Terminal, lines of below will be printed:
+
+Installing safe-rm will put `safe-rm` in your `/bin` directory. In order to use
+`safe-rm`, you need to add an alias to your `~/.bashrc` script and in all yours
+currently open terminals, like this:
+
+    alias rm='/bin/shell-safe-rm'
+
+After installation and alias definition, when you execute `rm` command in the Terminal, lines of below will be printed:
 
 	> rm
 	safe-rm
@@ -53,10 +58,11 @@ After installation, when you execute `rm` command in the Terminal, lines of belo
        unlink file
 
 which helps to tell safe-rm from the original rm.
-	
+
 ## Uninstall
 
 	make && sudo make uninstall
+
 Or
 
 	sudo sh uninstall.sh

--- a/bin/rm.sh
+++ b/bin/rm.sh
@@ -211,6 +211,7 @@ remove(){
 
         # if a directory, and without '-r' option
         if [[ ! -n "$OPT_RECURSIVE" ]]; then
+            debug "$LINENO: $file: is a directory"
             echo "$COMMAND: $file: is a directory"
             return 1
         fi

--- a/bin/rm.sh
+++ b/bin/rm.sh
@@ -353,7 +353,7 @@ debug "${#FILE_NAME[@]} files or directory to process: ${FILE_NAME[@]}"
 
 # test remove interactive_once: ask for 3 or more files or with recorsive option
 if [[ (${#FILE_NAME[@]} > 2 || $OPT_RECURSIVE = 1) && $OPT_INTERACTIVE_ONCE = 1 ]]; then
-  echo -n "$0: remove all arguments? "
+  echo -n "$COMMAND: remove all arguments? "
   read answer
 
   # actually, as long as the answer start with 'y', the file will be removed
@@ -366,7 +366,24 @@ fi
 
 for file in ${FILE_NAME[@]}
 do
+    if [[ $file = "/" ]]; then
+        echo "it is dangerous to operate recursively on /"
+        echo "are you insane?"
+        EXIT_CODE=1
+
+        # Exit immediately
+        debug "EXIT_CODE $EXIT_CODE"
+        exit $EXIT_CODE
+    fi
+
     if [[ $file = "." || $file = ".." ]]; then
+        echo "$COMMAND: \".\" and \"..\" may not be removed"
+        EXIT_CODE=1
+        continue
+    fi
+
+    #the same check also apply on /. /..
+    if [[ $(basename $file) = "." || $(basename $file) = ".." ]]; then
         echo "$COMMAND: \".\" and \"..\" may not be removed"
         EXIT_CODE=1
         continue

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 
-PREFIX=/bin
+PREFIX="/bin"
 
-if [ ! -e "$PREFIX/rm.bak" ]; then
-    echo "... backup $PREFIX/rm to $PREFIX/rm.bak"
-    cp $PREFIX/rm $PREFIX/rm.bak
-fi
-
-cp bin/rm.sh $PREFIX/rm
-chmod 755 $PREFIX/rm
-echo "Installation Succeeded! Enjoy!"
+cp bin/rm.sh $PREFIX/safe-rm
+chmod 755 $PREFIX/safe-rm
+echo "Installation Succeeded!"
+echo "Please add \"alias rm='$PREFIX/safe-rm'\" to your ~/.bashrc script"
+echo "Enjoy!"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-PREFIX=/bin
+PREFIX="/bin"
 
-cp $PREFIX/rm.bak $PREFIX/rm
-chmod 755 $PREFIX/rm
-echo "Successfully recovered to the original rm"
+rm $PREFIX/safe-rm
+echo "Please remove \"alias rm='$PREFIX/safe-rm'\" from your ~/.bashrc script"
+echo "and do 'unalias rm' from all your terminal sessions"
+echo "Successfully removed $PREFIX/safe-rm"


### PR DESCRIPTION
Hi kaelzhang,

I've added some modification on your script. Briefly:
- I've fixed the exit status on success (see this [issue](https://github.com/kaelzhang/shell-safe-rm/issues/6))
- I've added the `-I/--interactive=once` for asking only one time before removal (see `man rm` for details)
- The installation will not replace the default `rm` binary, I prompt a command to use `safe-rm` as an alias (see your [issue](https://github.com/kaelzhang/shell-safe-rm/issues/5))
- Other minor fixes

Regards,

Paolo
