### PR TITLE
Dealing with symlink pointing to directories (fix #11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ test:
 	@echo "Testing safe-rm by creating a directory and a symbolic link to it"
 	@mkdir /tmp/test_dir
 	@ln -s /tmp/test_dir /tmp/test_link
-	@bin/rm.sh /tmp/test_link
+	@echo yes | bin/rm.sh /tmp/test_link
 	@bin/rm.sh -r /tmp/test_dir
 	@cd $(OLDPWD)

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ test:
 	@echo "Testing safe-rm by creating a directory and a symbolic link to it"
 	@mkdir /tmp/test_dir
 	@ln -s /tmp/test_dir /tmp/test_link
-	@$(PREFIX)/safe-rm /tmp/test_link
-	@$(PREFIX)/safe-rm -r /tmp/test_dir
+	@bin/rm.sh /tmp/test_link
+	@bin/rm.sh -r /tmp/test_dir
 	@cd $(OLDPWD)

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,18 @@ uninstall:
 	@echo "and do 'unalias rm' from all your terminal sessions"
 	@echo "Successfully removed $(PREFIX)/safe-rm"
 
+# the test target will not work properly if a file named test is ever created
+# in this directory. Since it has no prerequisites, test would always be considered
+# up to date and its recipe would not be executed. To avoid this problem you
+# can explicitly declare the target to be phony by making it a prerequisite of
+# the special target
+# TODO: is test directory really needed?
+.PHONY: test
+
 test:
-	@echo "Testing safe-rm"
+	@echo "Testing safe-rm by creating a directory and a symbolic link to it"
+	@mkdir /tmp/test_dir
+	@ln -s /tmp/test_dir /tmp/test_link
+	@$(PREFIX)/safe-rm /tmp/test_link
+	@$(PREFIX)/safe-rm -r /tmp/test_dir
+	@cd $(OLDPWD)

--- a/bin/rm.sh
+++ b/bin/rm.sh
@@ -208,51 +208,51 @@ fi
 remove(){
   local file=$1
 
-  # if is dir
-  if [[ -d "$file" ]]; then
+  # if is dir and not a symbolick link
+  if [[ -d "$file" && ! -L "$file" ]]; then
 
-  # if a directory, and without '-r' option
-  if [[ ! -n "$OPT_RECURSIVE" ]]; then
-    debug "$LINENO: $file: is a directory"
-    echo "$COMMAND: $file: is a directory"
-    return 1
-  fi
-
-  if [[ $file = './' ]]; then
-    echo "$COMMAND: $file: Invalid argument"
-    return 1
-  fi
-
-  if [[ "$OPT_INTERACTIVE" = 1 ]]; then
-    echo -n "examine files in directory $file? "
-    read answer
-
-    # actually, as long as the answer start with 'y', the file will be removed
-    # default to no remove
-    if [[ ${answer:0:1} =~ [yY] ]]; then
-
-      # if choose to examine the dir, recursively check files first
-      recursive_remove $file
-
-      # interact with the dir at last
-      echo -n "remove $file? "
-      read answer
-      if [[ ${answer:0:1} =~ [yY] ]]; then
-        [[ $(ls -A "$file") ]] && {
-          echo "$COMMAND: $file: Directory not empty"
-
-          return 1
-
-        } || {
-          trash $file
-          debug "$LINENO: trash returned status $?"
-        }
-      fi
+    # if a directory, and without '-r' option
+    if [[ ! -n "$OPT_RECURSIVE" ]]; then
+      debug "$LINENO: $file: is a directory"
+      echo "$COMMAND: $file: is a directory"
+      return 1
     fi
-  else
-    trash $file
-    debug "$LINENO: trash returned status $?"
-  fi
+
+    if [[ $file = './' ]]; then
+      echo "$COMMAND: $file: Invalid argument"
+      return 1
+    fi
+
+    if [[ "$OPT_INTERACTIVE" = 1 ]]; then
+      echo -n "examine files in directory $file? "
+      read answer
+
+      # actually, as long as the answer start with 'y', the file will be removed
+      # default to no remove
+      if [[ ${answer:0:1} =~ [yY] ]]; then
+
+        # if choose to examine the dir, recursively check files first
+        recursive_remove $file
+
+        # interact with the dir at last
+        echo -n "remove $file? "
+        read answer
+        if [[ ${answer:0:1} =~ [yY] ]]; then
+          [[ $(ls -A "$file") ]] && {
+            echo "$COMMAND: $file: Directory not empty"
+
+            return 1
+
+          } || {
+            trash $file
+            debug "$LINENO: trash returned status $?"
+          }
+        fi
+      fi
+    else
+      trash $file
+      debug "$LINENO: trash returned status $?"
+    fi
 
   # if is a file
   else


### PR DESCRIPTION
Now shell-safe-rm will consider a symlink to a directory like a regular file; Added indentation in `directory` condition

