### PR TITLE
fixes issue #31 and #27: safe-rm prompts message when file contains whitespaces

### DIFF
--- a/bin/rm.sh
+++ b/bin/rm.sh
@@ -387,7 +387,7 @@ for file in "${FILE_NAME[@]}"; do
   fi
 
   #the same check also apply on /. /..
-  if [[ $(basename $file) = "." || $(basename $file) = ".." ]]; then
+  if [[ $(basename "$file") = "." || $(basename "$file") = ".." ]]; then
     echo "$COMMAND: \".\" and \"..\" may not be removed"
     EXIT_CODE=1
     continue


### PR DESCRIPTION
Fixes #31 and Fixes #27

Previously using safe-rm on a filename with multiple spaces in it would succeed, but produce an error message. Now it does not produce that error message.
e.g. `echo "s" > tmp\ tmp\ tmp.txt; ./rm.sh tmp\ tmp\ tmp.txt` Produced:
```
basename: extra operand ‘tmp.txt’
Try 'basename --help' for more information.
basename: extra operand ‘tmp.txt’
Try 'basename --help' for more information.
```

This occurs because the filename is passed into rm.sh as a single string with spaces, but back-slashes/quotes were not used when passing the filename into the `basename` command within the script. I added the necessary quotes.
