### PR TITLE
feat: Add `--permanently` flag to bypass trash and delete files permanently

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ For those implemented options, safe-rm will act **exactly the same** as the orig
 | `-f`, `--force` | **Force** | Removes files without prompting for confirmation, ignoring nonexistent files and overriding file protections |
 | `-r`, `-R`, `--recursive`, `--Recursive` | **Recursive** | Removes directories and their contents recursively. Required for deleting directories |
 | `-v`, `--verbose` | **Verbose** | Displays detailed information about each file or directory being removed |
-| `-d`, '--directory' | **Remove Empty Directories** | `safe-rm` can check and only remove empty directories specifically with this flag |
-| `-p`, '--permanently' | **Permanently remove** | Permanently remove files like in traditional `rm` |
+| `-d`, `--directory` | **Remove Empty Directories** | `safe-rm` can check and only remove empty directories specifically with this flag |
+| `-p`, `--permanently` | **Permanently remove** | Permanently remove files like in traditional `rm` |
 | `--` | **End of Options** | Used to indicate the end of options. Useful if a filename starts with a `-` |
 
 Combined short options are also supported, such as

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For those implemented options, safe-rm will act **exactly the same** as the orig
 | `-r`, `-R`, `--recursive`, `--Recursive` | **Recursive** | Removes directories and their contents recursively. Required for deleting directories |
 | `-v`, `--verbose` | **Verbose** | Displays detailed information about each file or directory being removed |
 | `-d`, '--directory' | **Remove Empty Directories** | `safe-rm` can check and only remove empty directories specifically with this flag |
+| `-p`, '--permanently' | **Permanently remove** | Permanently remove files like in traditional `rm` |
 | `--` | **End of Options** | Used to indicate the end of options. Useful if a filename starts with a `-` |
 
 Combined short options are also supported, such as

--- a/bin/rm.sh
+++ b/bin/rm.sh
@@ -300,7 +300,6 @@ for arg in ${ARG[@]}; do
     OPT_INTERACTIVE_ONCE=1;  debug "$LINENO: interactive_once  : $arg"
     OPT_INTERACTIVE=;
     ;;
-
   # both r and R is allowed
   -[rR]|--[rR]ecursive)
     OPT_RECURSIVE=1;    debug "$LINENO: recursive    : $arg"
@@ -313,6 +312,13 @@ for arg in ${ARG[@]}; do
 
   -d|--directory)
     OPT_EMPTY_DIR=1;    debug "$LINENO: empty dir    : $arg"
+    ;;
+  -p|--permanently)
+    # permanently delete files
+    rm ${ARG[@]/$arg} ${FILE_NAME[*]}
+    debug "$LINENO: permanently delete files: ${FILE_NAME[*]}"
+    do_exit $LINENO 0
+    #rm $@ && do_exit $LINENO 0
     ;;
 
   *)

--- a/bin/rm.sh
+++ b/bin/rm.sh
@@ -316,7 +316,7 @@ for arg in ${ARG[@]}; do
   -p|--permanently)
     # permanently delete files
     rm ${ARG[@]/$arg} ${FILE_NAME[*]}
-    debug "$LINENO: permanently delete files: ${FILE_NAME[*]}"
+    debug "$LINENO: permanently: rm ${ARG[@]/$arg} ${FILE_NAME[*]}"
     do_exit $LINENO 0
     #rm $@ && do_exit $LINENO 0
     ;;


### PR DESCRIPTION
## Description  
This PR adds a `--permanently` flag to `save-rm`, allowing users to bypass the trash and delete files like with traditional *rm*.  

### Changes:  
- Added `--permanently` (or `-P`) flag to skip trash and call `rm` directly.  
- Updated readme. 

## Motivation  
Currently, aliasing `rm=save-rm` makes it impossible to delete files permanently.  

## Example Usage  
```bash
save-rm --permanently file  # Deletes permanently
```

> [!IMPORTANT]
> I didn't write any tests but the changes are very simple. 